### PR TITLE
.NET 8, Telegram.Bot 22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.vs/*
+/.idea/
 /HrBot/obj/*
 /HrBot/bin/*
 /HrBot/appsettings.Production.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["HrBot/HrBot.csproj", "HrBot/"]
 RUN dotnet restore "HrBot/HrBot.csproj"

--- a/HrBot/Controllers/UpdateController.cs
+++ b/HrBot/Controllers/UpdateController.cs
@@ -39,22 +39,22 @@ namespace HrBot.Controllers
 
             try
             {
-                if (update.Type == UpdateType.Message)
+                if (update is { Type: UpdateType.Message, Message: {} message })
                 {
                     _logger.LogInformation(
                         "A message from received from {ChatId} {MessageId} {UserId}",
-                        update.Message.Chat.Id,
-                        update.Message.MessageId,
-                        update.Message.From.Id);
+                        message.Chat.Id,
+                        message.MessageId,
+                        message.From?.Id);
                     await _vacancyReposter.TryRepost(update.Message);
                 } 
-                else if (update.Type == UpdateType.EditedMessage)
+                else if (update is { Type: UpdateType.EditedMessage, EditedMessage: {} editedMessage })
                 {
                     _logger.LogInformation(
                         "An edited message received from {ChatId} {MessageId} {UserId}",
-                        update.EditedMessage.Chat.Id,
-                        update.EditedMessage.MessageId,
-                        update.EditedMessage.From.Id);
+                        editedMessage.Chat.Id,
+                        editedMessage.MessageId,
+                        editedMessage.From?.Id);
                     await _vacancyReposter.TryEdit(update.EditedMessage);
                 }
             }

--- a/HrBot/HrBot.csproj
+++ b/HrBot/HrBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
-    <PackageReference Include="Telegram.Bot" Version="15.7.1" />
+    <PackageReference Include="Telegram.Bot" Version="22.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.4" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/HrBot/HrBot.csproj
+++ b/HrBot/HrBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/HrBot/Services/RepostedMessagesMonitoringService.cs
+++ b/HrBot/Services/RepostedMessagesMonitoringService.cs
@@ -55,7 +55,7 @@ namespace HrBot.Services
         {
             var channelMessage = repostedMessage.To;
             
-            await _telegram.DeleteMessageAsync(channelMessage.ChatId, channelMessage.MessageId);
+            await _telegram.DeleteMessage(channelMessage.ChatId, channelMessage.MessageId);
         }
 
         private async Task<bool> IsRepostedMessageDeletedInChat(RepostedMessage repostedMessage)
@@ -64,12 +64,12 @@ namespace HrBot.Services
             var technicalChatId = _settings.TechnicalChatId;
             try
             {
-                var forwarded = await _telegram.ForwardMessageAsync(
+                var forwarded = await _telegram.ForwardMessage(
                     technicalChatId,
                     repostedMessage.From.ChatId,
                     repostedMessage.From.MessageId,
-                    true);
-                await _telegram.DeleteMessageAsync(forwarded.Chat.Id, forwarded.MessageId);
+                    disableNotification: true);
+                await _telegram.DeleteMessage(forwarded.Chat.Id, forwarded.MessageId);
 
                 return false;
             }

--- a/HrBot/Services/VacancyReposter.cs
+++ b/HrBot/Services/VacancyReposter.cs
@@ -72,7 +72,8 @@ namespace HrBot.Services
                     await TryDeleteMissingTagsWarning(message);
             }
 
-            if (_memoryCache.TryGetValue(GetKey(message), out ChatMessageId repostedMessageIds))
+            if (_memoryCache.TryGetValue(GetKey(message), out ChatMessageId? data)
+                && data is {} repostedMessageIds)
             {
                 await _telegramBot.EditMessageText(
                     repostedMessageIds.ChatId,
@@ -84,16 +85,13 @@ namespace HrBot.Services
 
         private async Task TryDeleteMissingTagsWarning(Message message)
         {
-            var hasWarningMessage = _memoryCache.TryGetValue(
-                GetErrorKey(message),
-                out ChatMessageId warningMessageIds);
-
-            if (!hasWarningMessage)
-                return;
-
-            await _telegramBot.DeleteMessage(
-                warningMessageIds.ChatId,
-                warningMessageIds.MessageId);
+            if (_memoryCache.TryGetValue(GetErrorKey(message), out ChatMessageId? data)
+                && data is { } warningMessageIds)
+            {
+                await _telegramBot.DeleteMessage(
+                    warningMessageIds.ChatId,
+                    warningMessageIds.MessageId);
+            }
         }
 
         private async Task SendMissingTagsWarning(Message message)

--- a/HrBot/Startup.cs
+++ b/HrBot/Startup.cs
@@ -1,8 +1,7 @@
+using HrBot.Services;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using HrBot.Services;
 using Microsoft.Extensions.Options;
 using Telegram.Bot;
 
@@ -24,7 +23,7 @@ namespace HrBot
 
             services.Configure<AppSettings>(Configuration.GetSection("Configuration"));
 
-            services.AddSingleton<ITelegramBotClient>(_ => new TelegramBotClient(Configuration["Configuration:BotToken"]));
+            services.AddSingleton<ITelegramBotClient>(_ => new TelegramBotClient(Configuration["Configuration:BotToken"]!));
 
             services.AddTransient<IVacancyReposter, VacancyReposter>();
             services.AddTransient<IVacancyAnalyzer, VacancyAnalyzer>();

--- a/HrBot/StartupExtensions.cs
+++ b/HrBot/StartupExtensions.cs
@@ -22,13 +22,13 @@ namespace HrBot
                     var logger = services.GetRequiredService<ILogger<Startup>>();
 
                     logger.LogInformation("Removing WebHook");
-                    await services.GetRequiredService<ITelegramBotClient>().DeleteWebhookAsync();
+                    await services.GetRequiredService<ITelegramBotClient>().DeleteWebhook();
 
                     logger.LogInformation($"Setting WebHook to {webHookAddress}");
-                    await services.GetRequiredService<ITelegramBotClient>().SetWebhookAsync(webHookAddress, maxConnections: 5);
+                    await services.GetRequiredService<ITelegramBotClient>().SetWebhook(webHookAddress, maxConnections: 5);
                     logger.LogInformation($"WebHook is set to {webHookAddress}");
 
-                    var webHookInfo = await services.GetRequiredService<ITelegramBotClient>().GetWebhookInfoAsync();
+                    var webHookInfo = await services.GetRequiredService<ITelegramBotClient>().GetWebhookInfo();
                     logger.LogInformation($"WebHook info: {JsonConvert.SerializeObject(webHookInfo)}");
                 });
 
@@ -37,7 +37,7 @@ namespace HrBot
                 {
                     var logger = services.GetService<ILogger<Startup>>();
 
-                    services.GetRequiredService<ITelegramBotClient>().DeleteWebhookAsync().Wait();
+                    services.GetRequiredService<ITelegramBotClient>().DeleteWebhook().Wait();
                     logger.LogInformation("WebHook removed");
                 });
 

--- a/HrBot/StartupExtensions.cs
+++ b/HrBot/StartupExtensions.cs
@@ -35,7 +35,7 @@ namespace HrBot
             lifetime.ApplicationStopping.Register(
                 () =>
                 {
-                    var logger = services.GetService<ILogger<Startup>>();
+                    var logger = services.GetRequiredService<ILogger<Startup>>();
 
                     services.GetRequiredService<ITelegramBotClient>().DeleteWebhook().Wait();
                     logger.LogInformation("WebHook removed");


### PR DESCRIPTION
- Telegram.Bot v15.7.1 → v22.6.2 (latest stable)
- .NET 5.0 (no longer supported) → .NET 8.0 (current LTS)

The original reason for the update was that the Telegram.Bot v15 doesn't support 64-bit user ids, which (_supposedly_) causes some issues in bot functioning.

The minimal update required to get on track would be to update to v16, but I decided to promote the dependencies to relatively recent versions.