### PR TITLE
Fix problems with receiving messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 /.vs/*
 /.idea/
-/HrBot/obj/*
-/HrBot/bin/*
 /HrBot/appsettings.Production.json
 /HrBot/appsettings.Development.json
 /HrBot/HrBot.csproj.user
 /HrBot/logs/*
 /HrBot/Configuration/appsettings.Development.json
 /HrBot/Configuration/appsettings.Production.json
+
+obj/
+bin/
+
 *.user

--- a/HrBot.Tests/HrBot.Tests.csproj
+++ b/HrBot.Tests/HrBot.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\HrBot\HrBot.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/HrBot.Tests/IntegrationTest.cs
+++ b/HrBot.Tests/IntegrationTest.cs
@@ -1,0 +1,69 @@
+﻿using System.Net;
+using System.Text;
+using HrBot.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Telegram.Bot.Types;
+
+namespace HrBot.Tests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((ctx, cfg) =>
+        {
+            var inMemorySettings = new Dictionary<string, string?>
+            {
+                ["Configuration:BotToken"] = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd",
+                ["Configuration:WebHookAddress"] = "https://example.test/webhook",
+                ["Configuration:RepostToChannelId"] = "-1001234567890",
+                ["Configuration:RepostOnlyFromChatIdsEnabled"] = "false",
+                ["Configuration:TechnicalChatId"] = "0"
+            };
+            cfg.AddInMemoryCollection(inMemorySettings!);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            // Replace IVacancyReposter to avoid heavy logic during tests
+            var reposterMock = new Mock<IVacancyReposter>();
+            reposterMock.Setup(r => r.TryRepost(It.IsAny<Message>())).Returns(Task.CompletedTask);
+            reposterMock.Setup(r => r.TryEdit(It.IsAny<Message>())).Returns(Task.CompletedTask);
+
+            var descriptorReposter = services.SingleOrDefault(d => d.ServiceType == typeof(IVacancyReposter));
+            if (descriptorReposter != null)
+                services.Remove(descriptorReposter);
+            services.AddSingleton(reposterMock.Object);
+        });
+    }
+}
+
+public class IntegrationTest : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public IntegrationTest(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task HrUpdate_Post_ReturnsOk()
+    {
+        var testBody = """
+                        {"update_id":1231223123,
+                       "message":{"message_id":757,"from":{"id":123123123,"is_bot":false,"first_name":"Dr.","last_name":"Redacted","username":"redacted","is_premium":true},"chat":{"id":-123123123123,"title":"Redacted 14","username":"redacted14","type":"supergroup"},"date":1758486604,"text":"\u044d\u043c, \u0442\u0435\u0441\u0442?"}}
+                       """;
+
+        using var content = new StringContent(testBody, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/api/hrupdate", content);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/HrBot.sln
+++ b/HrBot.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31025.218
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HrBot", "HrBot\HrBot.csproj", "{7F852489-637A-42CA-8738-0D72B9E6120F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HrBot.Tests", "HrBot.Tests\HrBot.Tests.csproj", "{7FD009E5-BAB7-4023-9D35-888569ED1FDC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7F852489-637A-42CA-8738-0D72B9E6120F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F852489-637A-42CA-8738-0D72B9E6120F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F852489-637A-42CA-8738-0D72B9E6120F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FD009E5-BAB7-4023-9D35-888569ED1FDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FD009E5-BAB7-4023-9D35-888569ED1FDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FD009E5-BAB7-4023-9D35-888569ED1FDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FD009E5-BAB7-4023-9D35-888569ED1FDC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HrBot/Properties/launchSettings.json
+++ b/HrBot/Properties/launchSettings.json
@@ -9,7 +9,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": "true",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:5001;http://localhost:4430"
     }
   }
 }

--- a/HrBot/Startup.cs
+++ b/HrBot/Startup.cs
@@ -18,7 +18,7 @@ namespace HrBot
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers();
             services.AddOptions();
 
             services.Configure<AppSettings>(Configuration.GetSection("Configuration"));

--- a/HrBot/Startup.cs
+++ b/HrBot/Startup.cs
@@ -2,6 +2,7 @@ using HrBot.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Telegram.Bot;
 
@@ -32,9 +33,13 @@ namespace HrBot
             services.AddTransient<IRepostedMessagesMonitoringService, RepostedMessagesMonitoringService>();
         }
 
-        public void Configure(IApplicationBuilder app, IOptions<AppSettings> appSettingsOptions)
+        public void Configure(IApplicationBuilder app, IOptions<AppSettings> appSettingsOptions, IHostEnvironment env)
         {
-            app.UseTelegramBotWebHook(appSettingsOptions.Value.WebHookAddress);
+            if (!env.IsEnvironment("Testing"))
+            {
+                app.UseTelegramBotWebHook(appSettingsOptions.Value.WebHookAddress);
+            }
+
             app.UseRouting();
             app.UseAuthorization();
             app.UseEndpoints(endpoints => endpoints.MapControllers());


### PR DESCRIPTION
It turns out all the current `POST` requests to the bot get error `400` because they cannot parse incoming messages.

The problem was that out that Telegram.Bot is now compatible with the default ASP.NET Core settings, and we were forcing it to use Newtonsoft.JSON.

More documentation: https://telegrambots.github.io/book/3/updates/webhook.html#configure-json-serialization-settings